### PR TITLE
Add simple Flutter app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub/
+build/
+
+# IDEs and editors
+.idea/
+.vscode/

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: 'Simple Flutter App',
+      home: Scaffold(
+        body: Center(
+          child: Text('Hello, Flutter!'),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: simple_flutter_app
+description: A simple Flutter app
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,10 @@
-#svr
+# Simple Flutter App
+
+This repository contains a minimal Flutter application that displays "Hello, Flutter!" on the screen.
+
+## Getting Started
+
+1. Install [Flutter](https://flutter.dev/docs/get-started/install).
+2. Run `flutter pub get` to fetch dependencies.
+3. Execute `flutter test` to run the widget test.
+4. Launch the application with `flutter run`.

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:simple_flutter_app/main.dart';
+
+void main() {
+  testWidgets('App displays greeting', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    expect(find.text('Hello, Flutter!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold basic Flutter app with greeting widget
- set up pubspec, .gitignore, and widget test

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c071376d7c83339c1d22f23d9df006