### PR TITLE
Add video recording button

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,53 @@
 import 'package:flutter/material.dart';
+import 'package:camera/camera.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
   @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  CameraController? _controller;
+  bool _isRecording = false;
+
+  Future<void> _toggleRecording() async {
+    if (_controller == null) {
+      final cameras = await availableCameras();
+      _controller = CameraController(cameras.first, ResolutionPreset.medium);
+      await _controller!.initialize();
+    }
+    if (_isRecording) {
+      await _controller!.stopVideoRecording();
+    } else {
+      await _controller!.startVideoRecording();
+    }
+    setState(() {
+      _isRecording = !_isRecording;
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      title: 'Simple Flutter App',
+    return MaterialApp(
+      title: 'Video Recorder',
       home: Scaffold(
         body: Center(
-          child: Text('Hello, Flutter!'),
+          child: ElevatedButton(
+            onPressed: _toggleRecording,
+            child: Text(_isRecording ? 'Stop Recording' : 'Start Recording'),
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  camera: ^0.10.5+2
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,8 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_flutter_app/main.dart';
 
 void main() {
-  testWidgets('App displays greeting', (WidgetTester tester) async {
+  testWidgets('App displays record button', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-    expect(find.text('Hello, Flutter!'), findsOneWidget);
+    expect(find.text('Start Recording'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add camera dependency
- show start/stop recording button using camera plugin
- update widget test for new button

## Testing
- ⚠️ `flutter analyze` (command not found)
- ⚠️ `flutter test` (command not found)
- ⚠️ `apt-get update` (403: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68c0754583b48333989e90cb4bebc7e8