### PR TITLE
Add flappy-style airplane game, game logic, assets, and CI APK build

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,37 @@
+name: Build Flutter APK
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+
+      - name: Install Dependencies
+        run: flutter pub get
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: flutter-apk
+          path: build/app/outputs/flutter-apk/app-release.apk

--- a/lib/game/airplane.dart
+++ b/lib/game/airplane.dart
@@ -1,0 +1,28 @@
+class Airplane {
+  Airplane({
+    required this.x,
+    required this.y,
+    this.width = 48,
+    this.height = 36,
+  });
+
+  final double x;
+  double y;
+  final double width;
+  final double height;
+  double velocityY = 0;
+
+  void update(double dt, double gravity) {
+    velocityY += gravity * dt;
+    y += velocityY * dt;
+  }
+
+  void jump(double jumpForce) {
+    velocityY = -jumpForce;
+  }
+
+  void reset(double startY) {
+    y = startY;
+    velocityY = 0;
+  }
+}

--- a/lib/game/game_controller.dart
+++ b/lib/game/game_controller.dart
@@ -1,0 +1,133 @@
+import 'dart:math';
+
+import 'airplane.dart';
+import 'skyscraper.dart';
+
+class GameController {
+  GameController()
+      : airplane = Airplane(x: 96, y: 300),
+        skyscrapers = [] {
+    _initializeSkyscrapers();
+  }
+
+  final Random _random = Random();
+
+  final Airplane airplane;
+  final List<Skyscraper> skyscrapers;
+
+  int score = 0;
+  bool gameOver = false;
+
+  double gravity = 900;
+  double jumpForce = 360;
+  double scrollSpeed = 140;
+  double groundHeight = 80;
+  double skyscraperWidth = 72;
+  double gapHeight = 170;
+  double skyscraperSpacing = 220;
+
+  void _initializeSkyscrapers() {
+    skyscrapers.clear();
+    for (var i = 0; i < 3; i++) {
+      skyscrapers.add(
+        Skyscraper(
+          x: 420 + i * skyscraperSpacing,
+          width: skyscraperWidth,
+          gapCenterY: 260,
+          gapHeight: gapHeight,
+        ),
+      );
+    }
+  }
+
+  void restart(double screenHeight) {
+    score = 0;
+    gameOver = false;
+    airplane.reset(screenHeight / 2 - airplane.height / 2);
+
+    for (var i = 0; i < skyscrapers.length; i++) {
+      skyscrapers[i].recycle(
+        newX: 420 + i * skyscraperSpacing,
+        screenHeight: screenHeight - groundHeight,
+        minGapMargin: 60,
+        random: _random,
+      );
+    }
+  }
+
+  void onTap() {
+    if (!gameOver) {
+      airplane.jump(jumpForce);
+    }
+  }
+
+  void update(double dt, double screenWidth, double screenHeight) {
+    if (gameOver) {
+      return;
+    }
+
+    final playableHeight = screenHeight - groundHeight;
+
+    airplane.update(dt, gravity);
+
+    for (final skyscraper in skyscrapers) {
+      skyscraper.update(dt, scrollSpeed);
+
+      if (!skyscraper.hasScored && skyscraper.x + skyscraper.width < airplane.x) {
+        skyscraper.hasScored = true;
+        score += 1;
+      }
+    }
+
+    final rightMostX = skyscrapers.map((s) => s.x).reduce(max);
+    for (final skyscraper in skyscrapers) {
+      if (skyscraper.x + skyscraper.width < 0) {
+        skyscraper.recycle(
+          newX: rightMostX + skyscraperSpacing,
+          screenHeight: playableHeight,
+          minGapMargin: 60,
+          random: _random,
+        );
+      }
+    }
+
+    if (_isOutOfBounds(playableHeight) || _hasCollision(playableHeight)) {
+      gameOver = true;
+    }
+
+    if (airplane.y < 0) {
+      airplane.y = 0;
+      airplane.velocityY = 0;
+    }
+  }
+
+  bool _isOutOfBounds(double playableHeight) {
+    return airplane.y + airplane.height >= playableHeight;
+  }
+
+  bool _hasCollision(double playableHeight) {
+    final planeLeft = airplane.x;
+    final planeRight = airplane.x + airplane.width;
+    final planeTop = airplane.y;
+    final planeBottom = airplane.y + airplane.height;
+
+    for (final skyscraper in skyscrapers) {
+      final left = skyscraper.x;
+      final right = skyscraper.x + skyscraper.width;
+
+      final horizontalOverlap = planeRight > left && planeLeft < right;
+      if (!horizontalOverlap) {
+        continue;
+      }
+
+      final topCollision = planeTop < skyscraper.topHeight;
+      final bottomCollision = planeBottom > skyscraper.bottomY(playableHeight);
+
+      if (topCollision || bottomCollision) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/lib/game/game_page.dart
+++ b/lib/game/game_page.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/material.dart';
+
+import 'game_controller.dart';
+
+class GamePage extends StatefulWidget {
+  const GamePage({super.key});
+
+  @override
+  State<GamePage> createState() => _GamePageState();
+}
+
+class _GamePageState extends State<GamePage> {
+  static const _frameDuration = Duration(milliseconds: 16);
+
+  final GameController _controller = GameController();
+  final AudioPlayer _jumpPlayer = AudioPlayer();
+  final AudioPlayer _crashPlayer = AudioPlayer();
+
+  Timer? _loop;
+  DateTime? _lastTickTime;
+  bool _playedCrash = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _startLoop();
+  }
+
+  void _startLoop() {
+    _loop?.cancel();
+    _lastTickTime = DateTime.now();
+
+    _loop = Timer.periodic(_frameDuration, (_) {
+      if (!mounted) {
+        return;
+      }
+
+      final now = DateTime.now();
+      final dt = now.difference(_lastTickTime!).inMilliseconds / 1000;
+      _lastTickTime = now;
+
+      final screenSize = MediaQuery.sizeOf(context);
+      final wasGameOver = _controller.gameOver;
+
+      setState(() {
+        _controller.update(dt, screenSize.width, screenSize.height);
+      });
+
+      if (!wasGameOver && _controller.gameOver) {
+        _playCrashSound();
+      }
+    });
+  }
+
+  Future<void> _playJumpSound() async {
+    await _jumpPlayer.stop();
+    await _jumpPlayer.play(AssetSource('sounds/jump.wav'));
+  }
+
+  Future<void> _playCrashSound() async {
+    if (_playedCrash) {
+      return;
+    }
+
+    _playedCrash = true;
+    await _crashPlayer.stop();
+    await _crashPlayer.play(AssetSource('sounds/crash.wav'));
+  }
+
+  void _onTap() {
+    if (_controller.gameOver) {
+      return;
+    }
+
+    _controller.onTap();
+    _playJumpSound();
+  }
+
+  void _restart() {
+    final screenHeight = MediaQuery.sizeOf(context).height;
+    setState(() {
+      _playedCrash = false;
+      _controller.restart(screenHeight);
+    });
+  }
+
+  @override
+  void dispose() {
+    _loop?.cancel();
+    _jumpPlayer.dispose();
+    _crashPlayer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final playableHeight = size.height - _controller.groundHeight;
+
+    return Scaffold(
+      body: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _onTap,
+        child: Stack(
+          children: [
+            Container(color: const Color(0xFF6EC6FF)),
+            for (final skyscraper in _controller.skyscrapers) ...[
+              Positioned(
+                left: skyscraper.x,
+                top: 0,
+                width: skyscraper.width,
+                height: skyscraper.topHeight,
+                child: Image.asset(
+                  'assets/images/skyscraper.png',
+                  fit: BoxFit.cover,
+                ),
+              ),
+              Positioned(
+                left: skyscraper.x,
+                top: skyscraper.bottomY(playableHeight),
+                width: skyscraper.width,
+                height: skyscraper.bottomHeight(playableHeight),
+                child: Image.asset(
+                  'assets/images/skyscraper.png',
+                  fit: BoxFit.cover,
+                ),
+              ),
+            ],
+            Positioned(
+              left: _controller.airplane.x,
+              top: _controller.airplane.y,
+              width: _controller.airplane.width,
+              height: _controller.airplane.height,
+              child: Image.asset('assets/images/airplane.png'),
+            ),
+            Positioned(
+              left: 0,
+              right: 0,
+              top: 50,
+              child: Text(
+                'Score: ${_controller.score}',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                  shadows: [
+                    Shadow(blurRadius: 8, color: Colors.black45, offset: Offset(1, 2)),
+                  ],
+                ),
+              ),
+            ),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: _controller.groundHeight,
+              child: Container(color: const Color(0xFF8D6E63)),
+            ),
+            if (_controller.gameOver)
+              Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Text(
+                      'Game Over',
+                      style: TextStyle(
+                        fontSize: 44,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    ElevatedButton(
+                      onPressed: _restart,
+                      child: const Text('Restart'),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/game/skyscraper.dart
+++ b/lib/game/skyscraper.dart
@@ -1,0 +1,39 @@
+import 'dart:math';
+
+class Skyscraper {
+  Skyscraper({
+    required this.x,
+    required this.width,
+    required this.gapCenterY,
+    required this.gapHeight,
+  });
+
+  double x;
+  final double width;
+  double gapCenterY;
+  final double gapHeight;
+  bool hasScored = false;
+
+  void update(double dt, double speed) {
+    x -= speed * dt;
+  }
+
+  void recycle({
+    required double newX,
+    required double screenHeight,
+    required double minGapMargin,
+    required Random random,
+  }) {
+    x = newX;
+    hasScored = false;
+    final minGapCenter = minGapMargin + gapHeight / 2;
+    final maxGapCenter = screenHeight - minGapMargin - gapHeight / 2;
+    gapCenterY = minGapCenter + random.nextDouble() * (maxGapCenter - minGapCenter);
+  }
+
+  double get topHeight => gapCenterY - gapHeight / 2;
+
+  double bottomY(double screenHeight) => gapCenterY + gapHeight / 2;
+
+  double bottomHeight(double screenHeight) => screenHeight - bottomY(screenHeight);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,55 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:camera/camera.dart';
+
+import 'game/game_page.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatefulWidget {
+class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
   @override
-  State<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> {
-  CameraController? _controller;
-  bool _isRecording = false;
-
-  Future<void> _toggleRecording() async {
-    if (_controller == null) {
-      final cameras = await availableCameras();
-      _controller = CameraController(cameras.first, ResolutionPreset.medium);
-      await _controller!.initialize();
-    }
-    if (_isRecording) {
-      await _controller!.stopVideoRecording();
-    } else {
-      await _controller!.startVideoRecording();
-    }
-    setState(() {
-      _isRecording = !_isRecording;
-    });
-  }
-
-  @override
-  void dispose() {
-    _controller?.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Video Recorder',
-      home: Scaffold(
-        body: Center(
-          child: ElevatedButton(
-            onPressed: _toggleRecording,
-            child: Text(_isRecording ? 'Stop Recording' : 'Start Recording'),
-          ),
-        ),
-      ),
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: GamePage(),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: simple_flutter_app
-description: A simple Flutter app
+description: A simple Flutter flappy-style airplane game
 publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  camera: ^0.10.5+2
+  audioplayers: ^6.0.0
 
 dev_dependencies:
   flutter_test:
@@ -17,3 +17,6 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/images/
+    - assets/sounds/

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,8 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_flutter_app/main.dart';
 
 void main() {
-  testWidgets('App displays record button', (WidgetTester tester) async {
+  testWidgets('Game displays initial score', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-    expect(find.text('Start Recording'), findsOneWidget);
+    expect(find.text('Score: 0'), findsOneWidget);
   });
 }


### PR DESCRIPTION
### Motivation
- Replace the previous camera sample with a simple flappy-style airplane game and provide a reproducible build pipeline. 
- Provide game logic, UI, and assets registration so the app can run as an interactive mobile game. 

### Description
- Added game model and logic with `lib/game/airplane.dart`, `lib/game/skyscraper.dart`, and `lib/game/game_controller.dart` implementing physics, obstacle recycling, scoring, and collision detection. 
- Implemented the UI and runtime loop in `lib/game/game_page.dart`, including touch handling, audio playback for jump/crash using `audioplayers`, and a restart flow. 
- Replaced the old camera-based `MyApp` with a `StatelessWidget` that launches `GamePage` in `lib/main.dart` and removed the `camera` dependency. 
- Updated `pubspec.yaml` to add `audioplayers`, expand the SDK constraint, and register `assets/images/` and `assets/sounds/`; added a CI workflow `/.github/workflows/build-apk.yml` to build and upload a release APK on pushes to `main`. 
- Updated the widget test in `test/widget_test.dart` to assert the game UI shows `Score: 0`. 

### Testing
- Ran the widget test with `flutter test` which exercises `test/widget_test.dart` and it passed. 
- Static analysis and local app launch were performed during development to verify the game loop and asset loads locally. 
- Added CI workflow `build-apk.yml` to build a release APK on `push` to `main` (workflow will run in CI on push).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab120a49c8833397221a15ca4406e7)