### PR TITLE
CI: generate Android host project when missing to fix APK build

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           channel: 'stable'
 
+      - name: Create Android host project files
+        run: |
+          if [ ! -d android ]; then
+            flutter create --platforms=android .
+          fi
+
       - name: Install Dependencies
         run: flutter pub get
 


### PR DESCRIPTION
### Motivation
- Fix the GitHub Actions failure `Your app is using an unsupported Gradle project` which occurs when the repository contains only Dart/Flutter sources and no Android host project, causing `flutter build apk --release` to fail.

### Description
- Added a step to `.github/workflows/build-apk.yml` after Flutter setup that conditionally runs `flutter create --platforms=android .` only when the `android/` directory is missing, so the APK build can run on lightweight repo layouts.

### Testing
- Ran `flutter --version` in this environment which failed because `flutter` is not installed here (`flutter: command not found`).
- Printed and inspected the updated workflow with `nl -ba .github/workflows/build-apk.yml` and confirmed the new conditional Android bootstrap step is present.
- Ran `git status --short` to verify the workflow file showed as modified locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab195f6adc8333bdd164481559e152)